### PR TITLE
Add ring and aws_lc_rs features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,8 +1004,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,15 @@ tokio = { version = "1.46.1", default-features = false, features = [
     "parking_lot",
     "rt",
 ] }
-tokio-rustls = "0.26.2"
+tokio-rustls = { version = "0.26.2", default-features = false }
 tokio-socks = { version = "0.5.2", optional = true }
 url = "2.5.4"
 webpki-roots = "1.0.2"
 
 [features]
-default = ["callback_client", "proxy"]
+default = ["callback_client", "proxy", "aws_lc_rs"]
+aws_lc_rs = ["tokio-rustls/aws_lc_rs"]
+ring = ["tokio-rustls/ring"]
 callback_client = ["proxy", "thiserror", "tokio/macros"]
 proxy = ["base64", "tokio-socks"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,10 @@ tokio = { version = "1.46.1", default-features = false, features = [
     "parking_lot",
     "rt",
 ] }
-tokio-rustls = { version = "0.26.2", default-features = false }
+tokio-rustls = { version = "0.26.2", default-features = false, features = [
+    "logging",
+    "tls12",
+] }
 tokio-socks = { version = "0.5.2", optional = true }
 url = "2.5.4"
 webpki-roots = "1.0.2"


### PR DESCRIPTION
tokio-rustls enables by default the aws_lc_rs feature, this pr enables downstream users to choose their crypto implementation while defaulting to aws_lc_rs.